### PR TITLE
NET-4240 - Snapshots are failing on Windows

### DIFF
--- a/safeio.go
+++ b/safeio.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // WriteToFile consumes the provided io.Reader and writes it to a temp
@@ -85,6 +86,9 @@ func Rename(oldname, newname string) error {
 }
 
 func syncParentDir(name string) error {
+	if runtime.GOOS == "windows" {
+		return nil
+	}
 	f, err := os.Open(filepath.Dir(name))
 	if err != nil {
 		return err

--- a/safeio.go
+++ b/safeio.go
@@ -86,6 +86,8 @@ func Rename(oldname, newname string) error {
 }
 
 func syncParentDir(name string) error {
+	// Skipping sync dir for windows
+	// because it is not supported.
 	if runtime.GOOS == "windows" {
 		return nil
 	}


### PR DESCRIPTION
PR addresses the issue in [NET-4240](https://hashicorp.atlassian.net/browse/NET-4240).

In windows we can not open directory - [Windows official documentation](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/open-wopen?view=msvc-170&redirectedfrom=MSDN). 

![Screenshot 2023-07-24 at 3 58 27 PM](https://github.com/rboyer/safeio/assets/134911583/34f103ba-34a9-495b-be90-c7a9765bd327)

Hence skipping the fsync for parent directory. Checked on windows node snapshot is creating successfully.